### PR TITLE
Allow setting via a Hash with String keys

### DIFF
--- a/lib/bitmask.rb
+++ b/lib/bitmask.rb
@@ -1,7 +1,7 @@
 class Bitmask
 
   attr_accessor :bit_ids, :after_change
-  attr_reader   :value
+  attr_reader   :value, :string_bit_ids
 
   def initialize ( options = {} )
     default_values = {
@@ -15,6 +15,7 @@ class Bitmask
 
     @value   = options[:value].to_i
     @bit_ids = options[:bit_ids]
+    @string_bit_ids = @bit_ids.map(&:to_s)
   end
 
   def get ( bit_id )

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -27,6 +27,7 @@ module BitmaskAttribute
 
         def #{options[:bitmask_object]}= new_bitmask_hash
           new_bitmask_hash.each do |key, val|
+            key = key.to_sym if #{options[:bitmask_object]}.string_bit_ids.include?(key)
             #{options[:bitmask_object]}[key] = val
           end
           #{options[:bitmask_object]}

--- a/test/test_bitmask.rb
+++ b/test/test_bitmask.rb
@@ -23,6 +23,10 @@ class TestBitmask < Test::Unit::TestCase
     assert @bitmask.bit_ids == [:flag1, :flag2, :flag3]
   end
 
+  def test_keeps_string_bit_ids
+    assert @bitmask.string_bit_ids == ["flag1", "flag2", "flag3"]
+  end
+
   def test_all_flags_are_false
     assert @bitmask.get(:flag1) == false
     assert @bitmask.get(:flag2) == false

--- a/test/test_bitmask_attribute.rb
+++ b/test/test_bitmask_attribute.rb
@@ -47,4 +47,17 @@ class TestBitmaskAttribute < Test::Unit::TestCase
     assert_raise(ArgumentError) { @something.flags_bitmask= { :i_dont_exist => true } }
   end
 
+  def test_setting_with_a_hash_with_string_keys
+    @something.flags_bitmask= { "flag1" => true, "flag2" => false, "flag3" => true }
+    assert @something.flags == 5
+
+    @something.flags_bitmask= { "flag1" => false }
+    assert @something.flags == 4
+
+    @something.flags_bitmask= { "flag2" => true }
+    assert @something.flags == 6
+
+    assert_raise(ArgumentError) { @something.flags_bitmask= { "i_dont_exist" => true } }
+  end
+
 end


### PR DESCRIPTION
This makes working with HashWithIndifferentAccess or ActionController::Parameters much easier.

@aukan it seems that when you gave me access to publish gems, you did not also give access to the git repo. I didn't want the gem to get out of date with the git repo, so I'm submitting this as a PR.
