### PR TITLE
Add :accessors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ algo.flags_bitmask.set(:flag1, false)
 algo.flags_bitmask.get(:flag1) # false
 algo.flags_bitmask.get(:flag2) # true
 ```
+
+To add accessor methods for each flag (`flag1`/`flag1?`/`flag1=`) pass the option `:accessors => true`.

--- a/lib/bitmask.rb
+++ b/lib/bitmask.rb
@@ -1,7 +1,7 @@
 class Bitmask
 
   attr_accessor :bit_ids, :after_change
-  attr_reader   :value
+  attr_reader   :value, :string_bit_ids
 
   def initialize ( options = {} )
     default_values = {
@@ -15,6 +15,7 @@ class Bitmask
 
     @value   = options[:value].to_i
     @bit_ids = options[:bit_ids]
+    @string_bit_ids = @bit_ids.map(&:to_s)
   end
 
   def get ( bit_id )

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -27,6 +27,7 @@ module BitmaskAttribute
 
         def #{options[:bitmask_object]}= new_bitmask_hash
           new_bitmask_hash.each do |key, val|
+            key = key.to_sym if #{options[:bitmask_object]}.string_bit_ids.include?(key)
             #{options[:bitmask_object]}[key] = val
           end
           #{options[:bitmask_object]}

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -38,6 +38,19 @@ module BitmaskAttribute
         send(options[:bitmask_object])
       end
 
+      if options[:accessors]
+        options[:bit_ids].each do |attr|
+          define_method(attr) do
+            send(options[:bitmask_object])[attr]
+          end
+          alias_method "#{attr}?", attr
+
+          define_method("#{attr}=") do |value|
+            send(options[:bitmask_object])[attr] = value
+          end
+        end
+      end
+
     end
 
   end

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -13,7 +13,6 @@ module BitmaskAttribute
       }
       options = default_options.merge(options)
 
-      bitmask_obj = options[:bitmask_object]
       class_eval <<-ADD_METHODS
         def #{options[:bitmask_object]}
           @_#{options[:bitmask_object]} ||= Bitmask.new({

--- a/lib/bitmask_attribute.rb
+++ b/lib/bitmask_attribute.rb
@@ -8,30 +8,35 @@ module BitmaskAttribute
 
     def bitmask_attribute ( attribute_name, options = {} )
       default_options = {
-        :bitmask_object => attribute_name.to_s + '_bitmask',
+        :bitmask_object => "#{attribute_name}_bitmask",
         :bit_ids => []
       }
       options = default_options.merge(options)
 
-      class_eval <<-ADD_METHODS
-        def #{options[:bitmask_object]}
-          @_#{options[:bitmask_object]} ||= Bitmask.new({
-            :bit_ids => #{options[:bit_ids].inspect},
-            :value => self.#{attribute_name},
-            :after_change => Proc.new { |bitmask|
-              self.#{attribute_name} = bitmask.value
-            }
-          })
+      define_method(options[:bitmask_object]) do
+        ivar_name = "@_#{options[:bitmask_object]}"
+        if instance_variable_defined?(ivar_name)
+          instance_variable_get(ivar_name)
+        else
+          instance_variable_set(ivar_name,
+            Bitmask.new(
+              :bit_ids => options[:bit_ids],
+              :value => send(attribute_name),
+              :after_change => Proc.new { |bitmask|
+                send("#{attribute_name}=", bitmask.value)
+              }
+            )
+          )
         end
+      end
 
-        def #{options[:bitmask_object]}= new_bitmask_hash
-          new_bitmask_hash.each do |key, val|
-            key = key.to_sym if #{options[:bitmask_object]}.string_bit_ids.include?(key)
-            #{options[:bitmask_object]}[key] = val
-          end
-          #{options[:bitmask_object]}
+      define_method("#{options[:bitmask_object]}=") do |new_bitmask_hash|
+        new_bitmask_hash.each do |key, val|
+          key = key.to_sym if send(options[:bitmask_object]).string_bit_ids.include?(key)
+          send(options[:bitmask_object])[key] = val
         end
-      ADD_METHODS
+        send(options[:bitmask_object])
+      end
 
     end
 

--- a/test/test_bitmask.rb
+++ b/test/test_bitmask.rb
@@ -23,6 +23,10 @@ class TestBitmask < Test::Unit::TestCase
     assert @bitmask.bit_ids == [:flag1, :flag2, :flag3]
   end
 
+  def test_keeps_string_bit_ids
+    assert @bitmask.string_bit_ids == ["flag1", "flag2", "flag3"]
+  end
+
   def test_all_flags_are_false
     assert @bitmask.get(:flag1) == false
     assert @bitmask.get(:flag2) == false

--- a/test/test_bitmask_attribute.rb
+++ b/test/test_bitmask_attribute.rb
@@ -47,4 +47,17 @@ class TestBitmaskAttribute < Test::Unit::TestCase
     assert_raise(ArgumentError) { @something.flags_bitmask= { :i_dont_exist => true } }
   end
 
+  def test_setting_with_a_hash_with_string_keys
+    @something.flags_bitmask= { "flag1" => true, "flag2" => false, "flag3" => true }
+    assert @something.flags == 5
+
+    @something.flags_bitmask= { "flag1" => false }
+    assert @something.flags == 4
+
+    @something.flags_bitmask= { "flag2" => true }
+    assert @something.flags == 6
+
+    assert_raise(ArgumentError) { @something.flags_bitmask= { "i_dont_exist" => true } }
+  end
+
 end

--- a/test/test_bitmask_attribute_accessors.rb
+++ b/test/test_bitmask_attribute_accessors.rb
@@ -1,0 +1,21 @@
+require File.dirname(__FILE__) + '/test_helper.rb'
+
+class TestBitmaskAttributeAccessors < Test::Unit::TestCase
+  class Something
+    attr_accessor :flags
+    include BitmaskAttribute
+    bitmask_attribute :flags,
+      :bit_ids => [:flag1, :flag2],
+      :accessors => true
+  end
+
+  def test_accessors
+    @something = Something.new
+    @something.flag1 = true
+    assert @something.flags == 1
+    assert @something.flag1
+    assert @something.flag1?
+    assert !@something.flag2
+    assert !@something.flag2?
+  end
+end


### PR DESCRIPTION
To add accessor methods for each flag (`flag1`/`flag1=`, etc.) pass the option `:accessors => true`.

Poll Everywhere has been using these convenience methods for a while and I'm extracting them out into this gem.

Dependent on #2 
